### PR TITLE
Linked the merge page to home tab

### DIFF
--- a/home.html
+++ b/home.html
@@ -255,7 +255,7 @@
                                  </h5>
                               </div>
                               <div class="slider__button overflow-hidden mt-32 mr-minus-col-2">
-                                 <a href="https://github.com/ethereum/pm/blob/master/Merge/mainnet-readiness.md" target="_blank" class="button -md -outline-black text-black invisible three">
+                                 <a href="the_merge" target="_blank" class="button -md -outline-black text-black invisible three">
                                  The Merge
                                  </a><span>
                                  <a href="eip_resources" class="button -md -outline-black text-black invisible three" style="margin-left: 20px;">

--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@
                                  </h5>
                               </div>
                               <div class="slider__button overflow-hidden mt-32 mr-minus-col-2">
-                                 <a href="https://github.com/ethereum/pm/blob/master/Merge/mainnet-readiness.md" target="_blank" class="button -md -outline-black text-black invisible three">
+                                 <a href="the_merge/" target="_blank" class="button -md -outline-black text-black invisible three">
                                  The Merge
                                  </a><span>
                                  <a href="eip_resources/" class="button -md -outline-black text-black invisible three" style="margin-left: 20px;">


### PR DESCRIPTION
This PR is to add the link in the home page missing from the previous PR: #33 

Specifically, changed the href in "The Merge" <a/> tag from the merge checklist to the merge info page for both index.html and home.html