### PR TITLE
Fix broken link on merge page

### DIFF
--- a/the_merge.html
+++ b/the_merge.html
@@ -148,7 +148,7 @@
                                        <a>Activities</a>
                                        <ul class="subnav-list">
                                           <li>
-                                             <a href="#">Network Upgrades</a>
+                                             <a href="network_upgrades">Network Upgrades</a>
                                           </li>
                                           <li>
                                              <a href="eip_resources">EIP Resources</a>


### PR DESCRIPTION
Fixes the **Network Upgrades** link in the subnav. Currently it is broke and doesn't navigate anywhere. 