### PR TITLE
[README] Add GitPOAP Badge to Display Number of Minted GitPOAPs for Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## Ethereum Cat Herder Website 
+[![gitpoap badge](https://public-api.gitpoap.io/v1/repo/ethereum-cat-herders/ech-website-v2/badge)](https://www.gitpoap.io/gh/ethereum-cat-herders/ech-website-v2)
 
 ### Purpose
 This repository is created to manage the content of EthereumCatHerders.com.


### PR DESCRIPTION
Hey all, this PR adds a [GitPOAP Badge](https://docs.gitpoap.io/api#get-v1repoownernamebadge) to the README that displays the number of minted GitPOAPs for this repository by contributors to this repo.

You can see an example of this in [our Documentation repository](https://github.com/gitpoap/gitpoap-docs#gitpoap-docs).

This should help would-be contributors as well as existing contributors find out that they will/have received GitPOAPs for their contributions.

CC: @colfax23 @kayla-henrie