### PR TITLE
Add devnets v6 + v7 to dencun updates

### DIFF
--- a/dencun/index.html
+++ b/dencun/index.html
@@ -536,6 +536,14 @@
                                             </h5>
                                             <div style="overflow-y: scroll;height: 680px;">
                                                 <h5 class="fw-300 mt-12 container">
+                                                    <span style="font-size: 18px; font-weight: 300;"><b>Jun 2023</b> :
+                                                        Launched EIP-4844 Devnet v7 (<a class="dashed-underline" target="_blank" href="https://notes.ethereum.org/@parithosh/devnet-7-specs">specs</a>)</span>
+                                                </h5>
+                                                <h5 class="fw-300 mt-12 container">
+                                                    <span style="font-size: 18px; font-weight: 300;"><b>Jun 2023</b> :
+                                                        Launched EIP-4844 Devnet v6 (<a class="dashed-underline" target="_blank" href="https://notes.ethereum.org/@bbusa/dencun-devnet-6">specs</a>)</span>
+                                                </h5>
+                                                <h5 class="fw-300 mt-12 container">
                                                     <span style="font-size: 18px; font-weight: 300;"><b>Apr 2023</b> :
                                                         Launched EIP-4844 Devnet v5 (<a class="dashed-underline" target="_blank" href="https://4844-devnet-5.ethpandaops.io/">guide</a>)</span>
                                                 </h5>


### PR DESCRIPTION
Added specs for Devnets 6 and 7 in the updates section of Dencun page.

Missing a valid link to Devnet 5 specs. Current one is no longer active and redirects to a 404.