### PR TITLE
Add devnet v8 to updates

### DIFF
--- a/dencun/index.html
+++ b/dencun/index.html
@@ -536,6 +536,10 @@
                                             </h5>
                                             <div style="overflow-y: scroll;height: 680px;">
                                                 <h5 class="fw-300 mt-12 container">
+                                                    <span style="font-size: 18px; font-weight: 300;"><b>Aug 2023</b> :
+                                                        Launched EIP-4844 Devnet v8 (<a class="dashed-underline" target="_blank" href="https://notes.ethereum.org/@ethpandaops/dencun-devnet-8">specs</a>)</span>
+                                                </h5>
+                                                <h5 class="fw-300 mt-12 container">
                                                     <span style="font-size: 18px; font-weight: 300;"><b>Jun 2023</b> :
                                                         Launched EIP-4844 Devnet v7 (<a class="dashed-underline" target="_blank" href="https://notes.ethereum.org/@parithosh/devnet-7-specs">specs</a>)</span>
                                                 </h5>


### PR DESCRIPTION
Modified the "Updates" section of the Dencun page to include the most recent devnet launch, V8 + its link.