### PR TITLE
Moved active survey to under completed

### DIFF
--- a/surveys/index.html
+++ b/surveys/index.html
@@ -282,13 +282,14 @@
                         <div class="row">
                         <div class="col-md-7 mobile-col-width-80">
                             
-                           <h2 class="fw-900 mt-24 container">Active</h2>
+                           <!-- <h2 class="fw-900 mt-24 container">Active</h2> -->
+                           
+                           
+                           <h2 class="fw-900 mt-24 container">Completed</h2>
                            
                            <h5 class="fw-300 mt-12 container dashed-underline">
                               <span><img class="pr-12 pl-32"src="../img/general/icon-paw.png"/><a class="dashed-underline" href="https://docs.google.com/forms/d/e/1FAIpQLSdxWpN_kcZj4I_43vME2MOKHq3yD5_OFv8Lj-RO14537r1GLA/viewform" target="_blank" >Ethereum Client Diversity Survey 2023</a></span>
                            </h5>
-                           
-                           <h2 class="fw-900 mt-24 container">Completed</h2>
                            
                            <h5 class="fw-300 mt-12 container dashed-underline">
                               <span><img class="pr-12 pl-32"src="../img/general/icon-paw.png"/><a class="dashed-underline" href="https://docs.google.com/forms/d/e/1FAIpQLSewZZNwEpQlLtsyF8Bs7XDuyWoEKDyo-t_ZUXiCP-BvF6HS3A/viewform" target="_blank" >Ethereum Cat Herders Community Feedback</a></span>

--- a/surveys/index.html
+++ b/surveys/index.html
@@ -288,7 +288,7 @@
                            <h2 class="fw-900 mt-24 container">Completed</h2>
                            
                            <h5 class="fw-300 mt-12 container dashed-underline">
-                              <span><img class="pr-12 pl-32"src="../img/general/icon-paw.png"/><a class="dashed-underline" href="https://docs.google.com/forms/d/e/1FAIpQLSdxWpN_kcZj4I_43vME2MOKHq3yD5_OFv8Lj-RO14537r1GLA/viewform" target="_blank" >Ethereum Client Diversity Survey 2023</a></span>
+                              <span><img class="pr-12 pl-32"src="../img/general/icon-paw.png"/><a class="dashed-underline" href="https://medium.com/ethereum-cat-herders/exploring-ethereums-client-ecosystem-afc9affa84dd" target="_blank" >Ethereum Client Diversity Survey 2023</a></span>
                            </h5>
                            
                            <h5 class="fw-300 mt-12 container dashed-underline">


### PR DESCRIPTION
Moved the client diversity survey from active to under completed. The href still links to the survey form. I can change it to a results or report link instead, if preferred. I also commented out the "Active" header since there are no active surveys at the moment.