### PR TITLE
Dencun Page: Add EIP-7495 card and removed some other sections

### DIFF
--- a/dencun/index.html
+++ b/dencun/index.html
@@ -299,15 +299,15 @@
                                         </br>
                                         <br>
                                         Dencun is a combination of two upgrades: (1) Deneb, the name for Consensus Layer upgrade, and (2) Cancun, the name of the Execution Layer upgrade. 
-                                        This upgrade will center around EIP-4844, but also includes a few other proposals.
+                                        This upgrade will center around EIP-4844, but will also include a few other proposals.
                                         </br>
                                     </h5>
-                                    <div class="container">
+                                    <!-- <div class="container">
                                         <a href="https://ethereum-magicians.org/t/cancun-network-upgrade-meta-thread/12060"
                                             target="_blank"><button
                                                 style="border: 2px solid black; border-radius: 5px;padding: 8px 15px;margin: 15px 0px;">Read
                                                 More</button></a>
-                                    </div>
+                                    </div> -->
                                 </div>
                                 
                                 <div class="col-md-5 mobile-col-width-80">
@@ -321,7 +321,7 @@
 
 
                             <!-- Readiness Checklist -->
-                            <section class="container" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 10px; margin-top: 100px;">
+                            <!-- <section class="container" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 10px; margin-top: 100px;">
                                 <div class="readinesschecklist">
                                     <h2>Readiness Checklist</h2>
                                     <p style="margin: 0px;font-size: 20px;">List of outstanding items
@@ -343,18 +343,7 @@
                                             href="https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/cancun.md"
                                             class="dashed-underline" target="_blank">here</a>.</p>
                                 </div>
-                                <!-- <div class="breakoutroom">
-                                    <h5 style="margin-bottom: 20px;">EOF Devnets Breakout Room</h5>
-                                    <iframe style="width: 100%;height: 60%;"
-                                        src="https://www.youtube.com/embed/videoseries?list=PL4cwHXAawZxpxjx7t3Aqo01pZYfHjaqG0"
-                                        title="YouTube video player" frameborder="0"
-                                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe>
-                                    <p style="font-size: 18px;margin: 10px 0px 0px;">Nov 4, 2022, 14:00 UTC</p>
-                                    <p style="font-size: 18px;margin: 10px 0px 0px"><a class="dashed-underline"
-                                            href="https://notes.ethereum.org/@timbeiko/eof-breakout"
-                                            target="_blank">Notes of the meeting</a></p>
-                                </div> -->
-                            </section>
+                            </section> -->
 
 
                             <!-- EIP Section -->
@@ -494,6 +483,25 @@
                                                     style="border: 2px solid black; border-radius: 5px;padding: 5px 10px;margin: 15px 0px;width: 49%;">EIP
                                                     Proposal</button></a>
                                             <a href="https://ethereum-magicians.org/t/eip-7045-increase-max-attestation-inclusion-slot/14342"
+                                                target="_blank"><button
+                                                    style="border: 2px solid black; border-radius: 5px;padding: 5px 10px;margin: 15px 0px;width: 49%;">EIP
+                                                    Discussion</button></a>
+                                        </div>
+                                    </div>
+                                    <div class="eipscol">
+                                        <a href="https://eips.ethereum.org/EIPS/eip-7495" target="_blank">
+                                            <h5>EIP-7495</h5>
+                                        </a>
+                                        <h5 style="text-align: justify; font-size: 20px; margin-top: 30px;height: 290px;"
+                                            class="fw-300"><i>EIP-7495: SSZ StableContainer</i>
+                                            introduces a new Simple Serialize (SSZ) type to represent a flexible container with stable serialization and merkleization even when individual fields become optional or new fields are introduced in the future.
+                                        </h5>
+
+                                        <div style="text-align: left;" class="">
+                                            <a href="https://eips.ethereum.org/EIPS/eip-7495" target="_blank"><button
+                                                    style="border: 2px solid black; border-radius: 5px;padding: 5px 10px;margin: 15px 0px;width: 49%;">EIP
+                                                    Proposal</button></a>
+                                            <a href="https://ethereum-magicians.org/t/eip-7495-ssz-stablecontainer/15476"
                                                 target="_blank"><button
                                                     style="border: 2px solid black; border-radius: 5px;padding: 5px 10px;margin: 15px 0px;width: 49%;">EIP
                                                     Discussion</button></a>


### PR DESCRIPTION
The following updates were made to the Dencun page:
- Add EIP-7495 card in inclusion list
- Remove readiness checklist and implementation progress table
- Remove "read more" button from hero section