### PR TITLE
Fix EIPs in shapella card and accordian

### DIFF
--- a/network_upgrades/index.html
+++ b/network_upgrades/index.html
@@ -308,10 +308,16 @@
                                  <span style="font-size: 16px; font-weight: 400;" class="post-digit"><i
                                        class=""></i>194048</span>
                            </h3>
+                           <a href="https://eips.ethereum.org/EIPS/eip-3651" target="_blank"
+                              class="mr-10 black-color">EIP-3651</a>
+                           <a href="https://eips.ethereum.org/EIPS/eip-3855" target="_blank"
+                              class="mr-10 black-color">EIP-3855</a>
+                           <a href="https://eips.ethereum.org/EIPS/eip-3860" target="_blank"
+                              class="mr-10 black-color">EIP-3860</a>
                            <a href="https://eips.ethereum.org/EIPS/eip-4895" target="_blank"
                               class="mr-10 black-color">EIP-4895</a>
-                           <a href="https://eips.ethereum.org/EIPS/eip-3540" target="_blank"
-                              class="mr-10 black-color">EIP-3540</a>
+                           <a href="https://eips.ethereum.org/EIPS/eip-6049" target="_blank"
+                              class="mr-10 black-color">EIP-6049</a>
    
                            <a href="https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md"
                               target="_blank" class="mr-10 black-color"><br>Execution Specs</a>
@@ -964,11 +970,20 @@
                               <ul style="list-style-position: inside;">
                                  <li><strong>Mainnet upgrade date</strong> - Wednesday, 12th of April</li>
                                  <li><strong>Epoch</strong> - 194048</li>
-                                 <li><a href="https://eips.ethereum.org/EIPS/eip-4895" rel="nofollow" target="_blank"
-                                       class="dashed-underline">EIP-4895 : Beacon chain push withdrawals as operations</a>
+                                 <li><a href="https://eips.ethereum.org/EIPS/eip-3651" rel="nofollow" target="_blank"
+                                       class="dashed-underline">EIP-3651: Warm COINBASE</a>
                                  </li>
-                                 <li><a href="https://eips.ethereum.org/EIPS/eip-3540" rel="nofollow" target="_blank"
-                                       class="dashed-underline">EIP-3540 : EVM Object Format (EOF) v1</a>
+                                 <li><a href="https://eips.ethereum.org/EIPS/eip-3855" rel="nofollow" target="_blank"
+                                    class="dashed-underline">EIP-3855: PUSH0 instruction</a>
+                                 </li>
+                                 <li><a href="https://eips.ethereum.org/EIPS/eip-3860" rel="nofollow" target="_blank"
+                                    class="dashed-underline">EIP-3860: Limit and meter initcode</a>
+                                 </li>
+                                 <li><a href="https://eips.ethereum.org/EIPS/eip-4895" rel="nofollow" target="_blank"
+                                    class="dashed-underline">EIP-4895 : Beacon chain push withdrawals as operations</a>
+                                 </li>
+                                 <li><a href="https://eips.ethereum.org/EIPS/eip-6049" rel="nofollow" target="_blank"
+                                    class="dashed-underline">EIP-6049: Deprecate SELFDESTRUCT</a>
                                  </li>
                                  <li><strong>Ethereum Foundation's </strong><a
                                        href="https://blog.ethereum.org/2023/03/28/shapella-mainnet-announcement"


### PR DESCRIPTION
A few EIPs were missing for Shapella in its card and accordian section of `/network-upgrades`. Also removed an EIP from there that was not actually included in the Shapella upgrade.