### PR TITLE
Dencun page: Edit content in updates and resources

### DIFF
--- a/dencun/index.html
+++ b/dencun/index.html
@@ -580,67 +580,10 @@
                                                     <span style="font-size: 18px; font-weight: 300;"><b>Oct 2022</b> :
                                                         Launched EIP-4844 Devnet v1 (<a class="dashed-underline" target="_blank" href="https://hackmd.io/@inphi/SJMXL1P6c">guide</a>)</span>
                                                 </h5>
-                                                <!-- <h5 class="fw-300 mt-12 container">
-                                                    <span style="font-size: 18px; font-weight: 300;"><b>2022-11-22</b> :
-                                                        Relaunch with
-                                                        EIP-4895 Withdrawals planned next week (updated)</span>
-                                                </h5>
                                                 <h5 class="fw-300 mt-12 container">
-                                                    <span style="font-size: 18px; font-weight: 300;"><b>2022-11-05</b> :
-                                                        Testnet restart at
-                                                        2022-11-05T10:54:46Z, new chainId 1337903</span>
+                                                    <span style="font-size: 18px; font-weight: 300;">
+                                                        <a class="dashed-underline" target="_blank" href="https://github.com/ethpandaops/dencun-testnet">Infrastructure Code for EIP-4844 Devnets</a></span>
                                                 </h5>
-                                                <h5 class="fw-300 mt-12 container">
-                                                    <span style="font-size: 18px; font-weight: 300;"><b>2022-11-02</b> :
-                                                        EIP-3860 consensus
-                                                        bug in block 6101, fix in the works</span>
-                                                </h5>
-                                                <h5 class="fw-300 mt-12 container">
-                                                    <span style="font-size: 18px; font-weight: 300;"><b>2022-10-26</b> :
-                                                        Restarted! 🤩 ❤️
-                                                        (Genesis: 1666736008, Oct 25 2022 22:13 UTC)</span>
-                                                </h5>
-                                                <h5 class="fw-300 mt-12 container">
-                                                    <span style="font-size: 18px; font-weight: 300;"><b>2022-10-25</b> :
-                                                        Shandong testnet
-                                                        restart (EIP-3540 and other fixes)</span>
-                                                </h5>
-                                                <h5 class="fw-300 mt-12 container">
-                                                    <span style="font-size: 18px; font-weight: 300;"><b>2022-10-19</b> :
-                                                        New PoW based faucet
-                                                        (thanks @pk910! ❤️ )</span>
-                                                </h5>
-                                                <h5 class="fw-300 mt-12 container">
-                                                    <span style="font-size: 18px; font-weight: 300;"><b>2022-10-18</b> :
-                                                        Various
-                                                        tx-submission-related stability fixes (tx pool,
-                                                        networking)</span>
-                                                </h5>
-                                                <h5 class="fw-300 mt-12 container">
-                                                    <span style="font-size: 18px; font-weight: 300;"><b>2022-10-17</b> :
-                                                        HCaptcha-based faucet
-                                                        being drained by bot (unstable)</span>
-                                                </h5>
-                                                <h5 class="fw-300 mt-12 container">
-                                                    <span style="font-size: 18px; font-weight: 300;"><b>2022-10-17</b> :
-                                                        Some Shandong media
-                                                        coverage</span>
-                                                </h5>
-                                                <h5 class="fw-300 mt-12 container">
-                                                    <span style="font-size: 18px; font-weight: 300;"><b>2022-10-17</b> :
-                                                        EIP-3540 not properly
-                                                        working, fix in the works</span>
-                                                </h5>
-                                                <h5 class="fw-300 mt-12 container">
-                                                    <span style="font-size: 18px; font-weight: 300;"><b>2022-10-14</b> :
-                                                        eth_estimateGas RPC
-                                                        method off, use higher gas price for txs</span>
-                                                </h5>
-                                                <h5 class="fw-300 mt-12 container">
-                                                    <span style="font-size: 18px; font-weight: 300;"><b>2022-10-13</b> :
-                                                        Shandong testnet
-                                                        launches (Twitter)</span>
-                                                </h5> -->
                                             </div>
                                         </div>
                                         <div style="display: flex; justify-content: center;align-items: center;flex-direction: column;"
@@ -711,12 +654,6 @@
                                                         style="font-size: 18px;margin-bottom: 10px;"
                                                         href="https://hackmd.io/@protolambda/blobs_l2_tx_usage"
                                                         target="_blank">EIP-4844 L2 TX usage & blob lifetime</span></a>
-                                            </h5>
-                                            <h5 class="fw-300 mt-12 container dashed-underline">
-                                                <span><a class="dashed-underline"
-                                                        style="font-size: 18px;margin-bottom: 10px;"
-                                                        href="https://hackmd.io/@adietrichs/4488-mining-analysis"
-                                                        target="_blank">EIP-4488 Mining Strategy & Stipend Analysis</span></a>
                                             </h5>
                                             <h5 class="fw-300 mt-12 container dashed-underline">
                                                 <span><a class="dashed-underline"


### PR DESCRIPTION
This PR adds a link to the dencun testnet infrastructure code repo under the Updates sections and removes "EIP-4488 Mining Strategy & Stipend Analysis" from the Resources section. Also removed some unused lines that were commented out.