### PR TITLE
Add EIP4844 Devnet 12 and Update Sub-Navigation

### DIFF
--- a/dencun/index.html
+++ b/dencun/index.html
@@ -562,6 +562,10 @@
                                             </h5>
                                             <div style="overflow-y: scroll;height: 680px;">
                                                 <h5 class="fw-300 mt-12 container">
+                                                    <span style="font-size: 18px; font-weight: 300;"><b>Nov 2023</b> :
+                                                        Launched EIP-4844 Devnet v12 (<a class="dashed-underline" target="_blank" href="https://notes.ethereum.org/@ethpandaops/dencun-devnet-12">specs</a>)</span>
+                                                </h5>
+                                                <h5 class="fw-300 mt-12 container">
                                                     <span style="font-size: 18px; font-weight: 300;"><b>Oct 2023</b> :
                                                         Launched EIP-4844 Devnet v11 (<a class="dashed-underline" target="_blank" href="https://notes.ethereum.org/@ethpandaops/dencun-devnet-11">specs</a>)</span>
                                                 </h5>

--- a/dencun/index.html
+++ b/dencun/index.html
@@ -274,6 +274,17 @@
                             </a>
                         </li>
                         <li>
+                            <a class="font-rob-darkgray" href="../testnets/">
+                                Testnets
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </section>
+            <section>
+                <div class="aligncenter mobile-d-none js-header-menu-classic mt-16">
+                    <ul class="navClassic-list js-navClassic-list">
+                        <li>
                             <a class="font-rob-darkgray" href="../podcast/">
                                 Podcasts
                             </a>

--- a/dev_meetings/index.html
+++ b/dev_meetings/index.html
@@ -240,7 +240,7 @@
                   </div>
                </div>
             </section>
-            <section>
+            <!-- <section>
                <div class="aligncenter mobile-d-none js-header-menu-classic">
                   <ul class="navClassic-list js-navClassic-list">
                      <li>
@@ -280,7 +280,59 @@
                      </li>
                   </ul>
                </div>
-            </section>
+            </section> -->
+            <section>
+               <div class="aligncenter mobile-d-none js-header-menu-classic">
+                   <ul class="navClassic-list js-navClassic-list">
+                       <li>
+                           <a class="font-rob-darkgray" href="../network_upgrades/">
+                               Network Upgrades
+                           </a>
+                       </li>
+                       <li>
+                           <a class="font-rob-darkgray" href="../dencun/">
+                               Dencun Upgrade
+                           </a>
+                       </li>
+                       <li>
+                           <a class="font-rob-darkgray" href="../eip/">
+                               EIP Resources
+                           </a>
+                       </li>
+                       <li>
+                           <a class="font-rob-black" href="../dev_meetings/">
+                               Meetings
+                           </a>
+                       </li>
+                       <li>
+                           <a class="font-rob-darkgray" href="../testnets/">
+                               Testnets
+                           </a>
+                       </li>
+                   </ul>
+               </div>
+           </section>
+           <section>
+               <div class="aligncenter mobile-d-none js-header-menu-classic mt-16">
+                   <ul class="navClassic-list js-navClassic-list">
+                       <li>
+                           <a class="font-rob-darkgray" href="../podcast/">
+                               Podcasts
+                           </a>
+                       </li>
+                       <li>
+                           <a class="font-rob-darkgray" href="../peepaneip/">
+                               PEEPanEIP
+                           </a>
+                       </li>
+                       <li>
+                           <a class="font-rob-darkgray" href="../surveys/">
+                               Surveys
+                           </a>
+                       </li>
+                   </ul>
+               </div>
+           </section>
             <!-- section end -->
             <section id="section-text" class="layout-pt-sm mobile-header-top-padding-0 ">
                <div class="container">

--- a/eip/index.html
+++ b/eip/index.html
@@ -244,7 +244,7 @@
                </div>
             </div>
          </section>
-         <section>
+         <!-- <section>
             <div class="aligncenter mobile-d-none js-header-menu-classic">
                <ul class="navClassic-list js-navClassic-list">
                   <li>
@@ -284,7 +284,59 @@
                   </li>
                </ul>
             </div>
-         </section>
+         </section> -->
+         <section>
+            <div class="aligncenter mobile-d-none js-header-menu-classic">
+                <ul class="navClassic-list js-navClassic-list">
+                    <li>
+                        <a class="font-rob-darkgray" href="../network_upgrades/">
+                            Network Upgrades
+                        </a>
+                    </li>
+                    <li>
+                        <a class="font-rob-darkgray" href="../dencun/">
+                            Dencun Upgrade
+                        </a>
+                    </li>
+                    <li>
+                        <a class="font-rob-black" href="../eip/">
+                            EIP Resources
+                        </a>
+                    </li>
+                    <li>
+                        <a class="font-rob-darkgray" href="../dev_meetings/">
+                            Meetings
+                        </a>
+                    </li>
+                    <li>
+                        <a class="font-rob-darkgray" href="../testnets/">
+                            Testnets
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </section>
+        <section>
+            <div class="aligncenter mobile-d-none js-header-menu-classic mt-16">
+                <ul class="navClassic-list js-navClassic-list">
+                    <li>
+                        <a class="font-rob-darkgray" href="../podcast/">
+                            Podcasts
+                        </a>
+                    </li>
+                    <li>
+                        <a class="font-rob-darkgray" href="../peepaneip/">
+                            PEEPanEIP
+                        </a>
+                    </li>
+                    <li>
+                        <a class="font-rob-darkgray" href="../surveys/">
+                            Surveys
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </section>
          <!-- section end -->
          <section id="section-text" class="layout-pt-sm mobile-header-top-padding-0 ">
             <div class="container">

--- a/network_upgrades/index.html
+++ b/network_upgrades/index.html
@@ -243,7 +243,7 @@
                </div>
             </div>
          </section>
-         <section>
+         <!-- <section>
             <div class="aligncenter mobile-d-none js-header-menu-classic">
                <ul class="navClassic-list js-navClassic-list">
                   <li>
@@ -276,6 +276,58 @@
                          PEEPanEIP
                      </a>
                  </li>
+                  <li>
+                     <a class="font-rob-darkgray" href="../surveys/">
+                        Surveys
+                     </a>
+                  </li>
+               </ul>
+            </div>
+         </section> -->
+         <section>
+            <div class="aligncenter mobile-d-none js-header-menu-classic">
+               <ul class="navClassic-list js-navClassic-list">
+                  <li>
+                     <a class="font-rob-black" href="../network_upgrades/">
+                        Network Upgrades
+                     </a>
+                  </li>
+                  <li>
+                     <a class="font-rob-darkgray" href="../dencun/">
+                        Dencun Upgrade
+                     </a>
+                  </li>
+                  <li>
+                     <a class="font-rob-darkgray" href="../eip/">
+                        EIP Resources
+                     </a>
+                  </li>
+                  <li>
+                     <a class="font-rob-darkgray" href="../dev_meetings/">
+                        Meetings
+                     </a>
+                  </li>
+                  <li>
+                     <a class="font-rob-darkgray" href="../testnets/">
+                        Testnets
+                     </a>
+                  </li>
+               </ul>
+            </div>
+         </section>
+         <section>
+            <div class="aligncenter mobile-d-none js-header-menu-classic mt-16">
+               <ul class="navClassic-list js-navClassic-list">
+                  <li>
+                     <a class="font-rob-darkgray" href="../podcast/">
+                        Podcasts
+                     </a>
+                  </li>
+                  <li>
+                     <a class="font-rob-darkgray" href="../peepaneip/">
+                        PEEPanEIP
+                     </a>
+                  </li>
                   <li>
                      <a class="font-rob-darkgray" href="../surveys/">
                         Surveys

--- a/peepaneip/index.html
+++ b/peepaneip/index.html
@@ -248,7 +248,7 @@
                     </div>
                 </div>
             </section>
-            <section>
+            <!-- <section>
                 <div class="aligncenter mobile-d-none js-header-menu-classic">
                     <ul class="navClassic-list js-navClassic-list">
                         <li>
@@ -273,6 +273,58 @@
                         </li>
                         <li>
                             <a class="font-rob-darkgray" href="../podcasts/">
+                                Podcasts
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-black" href="../peepaneip/">
+                                PEEPanEIP
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../surveys/">
+                                Surveys
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </section> -->
+            <section>
+                <div class="aligncenter mobile-d-none js-header-menu-classic">
+                    <ul class="navClassic-list js-navClassic-list">
+                        <li>
+                            <a class="font-rob-darkgray" href="../network_upgrades/">
+                                Network Upgrades
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../dencun/">
+                                Dencun Upgrade
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../eip/">
+                                EIP Resources
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../dev_meetings/">
+                                Meetings
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../testnets/">
+                                Testnets
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </section>
+            <section>
+                <div class="aligncenter mobile-d-none js-header-menu-classic mt-16">
+                    <ul class="navClassic-list js-navClassic-list">
+                        <li>
+                            <a class="font-rob-darkgray" href="../podcast/">
                                 Podcasts
                             </a>
                         </li>

--- a/podcast/index.html
+++ b/podcast/index.html
@@ -247,7 +247,7 @@
                     </div>
                 </div>
             </section>
-            <section>
+            <!-- <section>
                 <div class="aligncenter mobile-d-none js-header-menu-classic">
                     <ul class="navClassic-list js-navClassic-list">
                         <li>
@@ -272,6 +272,58 @@
                         </li>
                         <li>
                             <a class="font-rob-black" href="../podcasts">
+                                Podcasts
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../peepaneip/">
+                                PEEPanEIP
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../surveys/">
+                                Surveys
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </section> -->
+            <section>
+                <div class="aligncenter mobile-d-none js-header-menu-classic">
+                    <ul class="navClassic-list js-navClassic-list">
+                        <li>
+                            <a class="font-rob-darkgray" href="../network_upgrades/">
+                                Network Upgrades
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../dencun/">
+                                Dencun Upgrade
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../eip/">
+                                EIP Resources
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../dev_meetings/">
+                                Meetings
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../testnets/">
+                                Testnets
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </section>
+            <section>
+                <div class="aligncenter mobile-d-none js-header-menu-classic mt-16">
+                    <ul class="navClassic-list js-navClassic-list">
+                        <li>
+                            <a class="font-rob-black" href="../podcast/">
                                 Podcasts
                             </a>
                         </li>

--- a/shanghai_upgrade/index.html
+++ b/shanghai_upgrade/index.html
@@ -250,7 +250,7 @@
                     </div>
                 </div>
             </section>
-            <section>
+            <!-- <section>
                 <div class="aligncenter mobile-d-none js-header-menu-classic">
                     <ul class="navClassic-list js-navClassic-list">
                         <li>
@@ -273,6 +273,58 @@
                                 Meetings
                             </a>
                         </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../podcast/">
+                                Podcasts
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../peepaneip/">
+                                PEEPanEIP
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../surveys/">
+                                Surveys
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </section> -->
+            <section>
+                <div class="aligncenter mobile-d-none js-header-menu-classic">
+                    <ul class="navClassic-list js-navClassic-list">
+                        <li>
+                            <a class="font-rob-darkgray" href="../network_upgrades/">
+                                Network Upgrades
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../dencun/">
+                                Dencun Upgrade
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../eip/">
+                                EIP Resources
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../dev_meetings/">
+                                Meetings
+                            </a>
+                        </li>
+                        <li>
+                            <a class="font-rob-darkgray" href="../testnets/">
+                                Testnets
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </section>
+            <section>
+                <div class="aligncenter mobile-d-none js-header-menu-classic mt-16">
+                    <ul class="navClassic-list js-navClassic-list">
                         <li>
                             <a class="font-rob-darkgray" href="../podcast/">
                                 Podcasts

--- a/surveys/index.html
+++ b/surveys/index.html
@@ -242,7 +242,7 @@
                   </div>
                </div>
             </section>
-            <section>
+            <!-- <section>
                <div class="aligncenter mobile-d-none js-header-menu-classic">
                   <ul class="navClassic-list js-navClassic-list">
                      <li>
@@ -282,7 +282,59 @@
                      </li>
                   </ul>
                </div>
-            </section>
+            </section> -->
+            <section>
+               <div class="aligncenter mobile-d-none js-header-menu-classic">
+                   <ul class="navClassic-list js-navClassic-list">
+                       <li>
+                           <a class="font-rob-darkgray" href="../network_upgrades/">
+                               Network Upgrades
+                           </a>
+                       </li>
+                       <li>
+                           <a class="font-rob-darkgray" href="../dencun/">
+                               Dencun Upgrade
+                           </a>
+                       </li>
+                       <li>
+                           <a class="font-rob-darkgray" href="../eip/">
+                               EIP Resources
+                           </a>
+                       </li>
+                       <li>
+                           <a class="font-rob-darkgray" href="../dev_meetings/">
+                               Meetings
+                           </a>
+                       </li>
+                       <li>
+                           <a class="font-rob-darkgray" href="../testnets/">
+                               Testnets
+                           </a>
+                       </li>
+                   </ul>
+               </div>
+           </section>
+           <section>
+               <div class="aligncenter mobile-d-none js-header-menu-classic mt-16">
+                   <ul class="navClassic-list js-navClassic-list">
+                       <li>
+                           <a class="font-rob-darkgray" href="../podcast/">
+                               Podcasts
+                           </a>
+                       </li>
+                       <li>
+                           <a class="font-rob-darkgray" href="../peepaneip/">
+                               PEEPanEIP
+                           </a>
+                       </li>
+                       <li>
+                           <a class="font-rob-black" href="../surveys/">
+                               Surveys
+                           </a>
+                       </li>
+                   </ul>
+               </div>
+           </section>
             <!-- section end -->
 
 

--- a/testnets/index.html
+++ b/testnets/index.html
@@ -247,7 +247,7 @@
           </div>
         </div>
       </section>
-      <section>
+      <!-- <section>
         <div class="aligncenter mobile-d-none js-header-menu-classic">
           <ul class="navClassic-list js-navClassic-list">
             <li>
@@ -287,7 +287,59 @@
             </li>
           </ul>
         </div>
-      </section>
+      </section> -->
+      <section>
+        <div class="aligncenter mobile-d-none js-header-menu-classic">
+            <ul class="navClassic-list js-navClassic-list">
+                <li>
+                    <a class="font-rob-darkgray" href="../network_upgrades/">
+                        Network Upgrades
+                    </a>
+                </li>
+                <li>
+                    <a class="font-rob-darkgray" href="../dencun/">
+                        Dencun Upgrade
+                    </a>
+                </li>
+                <li>
+                    <a class="font-rob-darkgray" href="../eip/">
+                        EIP Resources
+                    </a>
+                </li>
+                <li>
+                    <a class="font-rob-darkgray" href="../dev_meetings/">
+                        Meetings
+                    </a>
+                </li>
+                <li>
+                    <a class="font-rob-black" href="../testnets/">
+                        Testnets
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </section>
+    <section>
+        <div class="aligncenter mobile-d-none js-header-menu-classic mt-16">
+            <ul class="navClassic-list js-navClassic-list">
+                <li>
+                    <a class="font-rob-darkgray" href="../podcast/">
+                        Podcasts
+                    </a>
+                </li>
+                <li>
+                    <a class="font-rob-darkgray" href="../peepaneip/">
+                        PEEPanEIP
+                    </a>
+                </li>
+                <li>
+                    <a class="font-rob-darkgray" href="../surveys/">
+                        Surveys
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </section>
       <!-- section end -->
 
 

--- a/the_merge/index.html
+++ b/the_merge/index.html
@@ -249,7 +249,7 @@
                </div>
             </div>
          </section>
-         <section>
+         <!-- <section>
             <div class="aligncenter mobile-d-none js-header-menu-classic">
                <ul class="navClassic-list js-navClassic-list">
                   <li>
@@ -289,7 +289,59 @@
                   </li>
                </ul>
             </div>
-         </section>
+         </section> -->
+         <section>
+            <div class="aligncenter mobile-d-none js-header-menu-classic">
+                <ul class="navClassic-list js-navClassic-list">
+                    <li>
+                        <a class="font-rob-darkgray" href="../network_upgrades/">
+                            Network Upgrades
+                        </a>
+                    </li>
+                    <li>
+                        <a class="font-rob-darkgray" href="../dencun/">
+                            Dencun Upgrade
+                        </a>
+                    </li>
+                    <li>
+                        <a class="font-rob-darkgray" href="../eip/">
+                            EIP Resources
+                        </a>
+                    </li>
+                    <li>
+                        <a class="font-rob-darkgray" href="../dev_meetings/">
+                            Meetings
+                        </a>
+                    </li>
+                    <li>
+                        <a class="font-rob-darkgray" href="../testnets/">
+                            Testnets
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </section>
+        <section>
+            <div class="aligncenter mobile-d-none js-header-menu-classic mt-16">
+                <ul class="navClassic-list js-navClassic-list">
+                    <li>
+                        <a class="font-rob-darkgray" href="../podcast/">
+                            Podcasts
+                        </a>
+                    </li>
+                    <li>
+                        <a class="font-rob-darkgray" href="../peepaneip/">
+                            PEEPanEIP
+                        </a>
+                    </li>
+                    <li>
+                        <a class="font-rob-darkgray" href="../surveys/">
+                            Surveys
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </section>
          <!-- section end -->
          <section id="section-text" class="layout-pt-sm mobile-header-top-padding-0">
             <div class="container">


### PR DESCRIPTION
This PR adds devnet 12 and link to its spec to the Updates section in the Dencun page. I also added the Testnets page to the sub navigation which required slight change in format to fit. Instead of one row, it is now two rows.