### PR TITLE
Update and sync activity nav for mobile

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -97,6 +97,9 @@
                                  <a href="../dev_meetings/">Meetings</a>
                               </li>
                               <li>
+                                 <a href="../testnets/">Testnets</a>
+                              </li>
+                              <li>
                                  <a href="../podcast/">Podcasts</a>
                               </li>
                               <li>

--- a/blog/index.html
+++ b/blog/index.html
@@ -98,6 +98,9 @@
                                  <a href="../dev_meetings/">Meetings</a>
                               </li>
                               <li>
+                                 <a href="../testnets/">Testnets</a>
+                              </li>
+                              <li>
                                  <a href="../podcast/">Podcasts</a>
                               </li>
                               <li>

--- a/branding/index.html
+++ b/branding/index.html
@@ -193,6 +193,9 @@
                                              <a href="../dev_meetings/">Meetings</a>
                                           </li>
                                           <li>
+                                             <a href="../testnets/">Testnets</a>
+                                          </li>
+                                          <li>
                                              <a href="../podcast/">Podcasts</a>
                                           </li>
                                           <li>

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -197,6 +197,9 @@
                                              <a href="../dev_meetings/">Meetings</a>
                                           </li>
                                           <li>
+                                             <a href="../testnets/">Testnets</a>
+                                          </li>
+                                          <li>
                                              <a href="../podcast/">Podcasts</a>
                                           </li>
                                           <li>

--- a/dencun/index.html
+++ b/dencun/index.html
@@ -172,6 +172,9 @@
                                                         <a href="../dev_meetings/">Meetings</a>
                                                     </li>
                                                     <li>
+                                                        <a href="../testnets/">Testnets</a>
+                                                    </li>
+                                                    <li>
                                                         <a href="../podcast/">Podcasts</a>
                                                     </li>
                                                     <li>

--- a/dev_meetings/index.html
+++ b/dev_meetings/index.html
@@ -165,6 +165,9 @@
                                              <a href="../dev_meetings/">Meetings</a>
                                           </li>
                                           <li>
+                                             <a href="../testnets/">Testnets</a>
+                                          </li>
+                                          <li>
                                              <a href="../podcast">Podcasts</a>
                                           </li>
                                           <li>

--- a/ech_youtube/index.html
+++ b/ech_youtube/index.html
@@ -193,6 +193,9 @@
                                              <a href="../dev_meetings/">Meetings</a>
                                           </li>
                                           <li>
+                                             <a href="../testnets/">Testnets</a>
+                                          </li>
+                                          <li>
                                              <a href="../podcast/">Podcasts</a>
                                           </li>
                                           <li>

--- a/eip/index.html
+++ b/eip/index.html
@@ -169,6 +169,9 @@
                                           <a href="../dev_meetings/">Meetings</a>
                                        </li>
                                        <li>
+                                          <a href="../testnets/">Testnets</a>
+                                       </li>
+                                       <li>
                                           <a href="../podcast/">Podcasts</a>
                                        </li>
                                        <li>

--- a/index.html
+++ b/index.html
@@ -187,10 +187,16 @@
                                           <a href="network_upgrades">Network Upgrades</a>
                                        </li>
                                        <li>
+                                          <a href="../dencun/">Dencun Upgrade</a>
+                                       </li>
+                                       <li>
                                           <a href="eip">EIP Resources</a>
                                        </li>
                                        <li>
                                           <a href="dev_meetings">Meetings</a>
+                                       </li>
+                                       <li>
+                                          <a href="../testnets/">Testnets</a>
                                        </li>
                                        <li>
                                           <a href="podcast">Podcasts</a>

--- a/network_upgrades/index.html
+++ b/network_upgrades/index.html
@@ -168,6 +168,9 @@
                                           <a href="../dev_meetings/">Meetings</a>
                                        </li>
                                        <li>
+                                          <a href="../testnets/">Testnets</a>
+                                       </li>
+                                       <li>
                                           <a href="../podcast/">Podcasts</a>
                                        </li>
                                        <li>

--- a/peepaneip/index.html
+++ b/peepaneip/index.html
@@ -170,6 +170,9 @@
                                                         <a href="../dev_meetings/">Meetings</a>
                                                     </li>
                                                     <li>
+                                                        <a href="../testnets/">Testnets</a>
+                                                    </li>
+                                                    <li>
                                                         <a href="../podcasts/">Podcasts</a>
                                                     </li>
                                                     <li>

--- a/podcast/index.html
+++ b/podcast/index.html
@@ -169,11 +169,14 @@
                                                         <a href="../dev_meetings/">Meetings</a>
                                                     </li>
                                                     <li>
+                                                        <a href="../testnets/">Testnets</a>
+                                                    </li>
+                                                    <li>
                                                         <a href="../podcast/">Podcasts</a>
-                                                     </li>
-                                                     <li>
+                                                    </li>
+                                                    <li>
                                                         <a href="../peepaneip/">PEEPanEIP</a>
-                                                     </li>
+                                                    </li>
                                                     <li>
                                                         <a href="../surveys/" target="_blank">Surveys</a>
                                                     </li>

--- a/shanghai_upgrade/index.html
+++ b/shanghai_upgrade/index.html
@@ -172,6 +172,9 @@
                                                         <a href="../dev_meetings/">Meetings</a>
                                                     </li>
                                                     <li>
+                                                        <a href="../testnets/">Testnets</a>
+                                                    </li>
+                                                    <li>
                                                         <a href="../podcast/">Podcasts</a>
                                                     </li>
                                                     <li>

--- a/surveys/index.html
+++ b/surveys/index.html
@@ -167,6 +167,9 @@
                                              <a href="../dev_meetings/">Meetings</a>
                                           </li>
                                           <li>
+                                             <a href="../testnets/">Testnets</a>
+                                          </li>
+                                          <li>
                                              <a href="../podcast/">Podcasts</a>
                                           </li>
                                           <li>

--- a/testnets/index.html
+++ b/testnets/index.html
@@ -172,6 +172,9 @@
                             <a href="../dev_meetings/">Meetings</a>
                           </li>
                           <li>
+                            <a href="../testnets/">Testnets</a>
+                          </li>
+                          <li>
                             <a href="../podcast/">Podcasts</a>
                           </li>
                           <li>

--- a/the_merge/index.html
+++ b/the_merge/index.html
@@ -174,6 +174,9 @@
                                           <a href="../dev_meetings/">Meetings</a>
                                        </li>
                                        <li>
+                                          <a href="../testnets/">Testnets</a>
+                                       </li>
+                                       <li>
                                           <a href="../podcast/">Podcasts</a>
                                        </li>
                                        <li>


### PR DESCRIPTION
Testnet and Dencun was missing on the Activity sub-navigation in mobile screen view. This PR fixes that.